### PR TITLE
[FLOC-3302] simple query api

### DIFF
--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -28,7 +28,7 @@ class IBackend(Interface):
         :return: A Deferred that fires with the result in the JSON format.
         """
 
-    def query(filter):
+    def query(filter, limit):
         """
         Retrieve previously stored results that match the given filter.
 
@@ -36,7 +36,9 @@ class IBackend(Interface):
         filter for the fields that are specified in the filter.
 
         :param dict filter: The filter in the JSON compatible format.
-        :return: A Deferred that fires with the results in the JSON format.
+        :param int limit: The number of the *latest* results to return.
+        :return: A Deferred that fires with a list of the results
+            in the JSON compatible format.
         """
 
     def delete(id):

--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -36,7 +36,8 @@ class IBackend(Interface):
         filter for the fields that are specified in the filter.
 
         :param dict filter: The filter in the JSON compatible format.
-        :param int limit: The number of the *latest* results to return.
+        :param int limit: The number of the results to return. The
+            results are sorted by their timestamp in descending order.
         :return: A Deferred that fires with a list of the results
             in the JSON compatible format.
         """

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -36,9 +36,7 @@ class ResultNotFound(Exception):
 @implementer(IBackend)
 class InMemoryBackend(object):
     """
-    The backend that simply drops all results.
-
-    :ivar dict results: Stored results by their identifiers.
+    The backend that keeps the results in the memory.
     """
     def __init__(self):
         self._results = OrderedDict()

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -5,6 +5,7 @@ A HTTP REST API for storing benchmark results.
 
 import sys
 
+from collections import OrderedDict
 from json import dumps, loads
 from uuid import uuid4
 from urlparse import urljoin
@@ -40,7 +41,7 @@ class InMemoryBackend(object):
     :ivar dict results: Stored results by their identifiers.
     """
     def __init__(self):
-        self._results = {}
+        self._results = OrderedDict()
 
     def store(self, result):
         """
@@ -63,14 +64,16 @@ class InMemoryBackend(object):
         except KeyError:
             return fail(ResultNotFound())
 
-    def query(self, filter):
+    def query(self, filter, limit):
         """
         Return matching results.
         """
         matching = [
-            r for r in self._results.viewvalues()
+            r for r in reversed(self._results.values())
             if filter.viewitems() <= r.viewitems()
         ]
+        if limit > 0:
+            matching = matching[:limit]
         return succeed(matching)
 
     def delete(self, id):

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -129,7 +129,9 @@ class BenchmarkAPI_V1(object):
         try:
             json = loads(request.content.read())
             json['userdata']['branch']
-        except (ValueError, KeyError) as e:
+        except KeyError as e:
+            raise BadRequest("'{}' is missing".format(e.message))
+        except ValueError as e:
             raise BadRequest(e.message)
 
         d = self.backend.store(json)

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -128,7 +128,8 @@ class BenchmarkAPI_V1(object):
         request.setHeader(b'content-type', b'application/json')
         try:
             json = loads(request.content.read())
-        except ValueError as e:
+            json['userdata']['branch']
+        except (ValueError, KeyError) as e:
             raise BadRequest(e.message)
 
         d = self.backend.store(json)

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -192,11 +192,12 @@ class BenchmarkAPI_V1(object):
         """
         Query the previously stored benchmarking results.
 
-        Currently this method supports filtering only by the branch name.
-        There is no support for the results paging, but a limit on the number
-        of the results is supported.
-        The order of the results is fixed at the moment and it's by
-        by the result timestamp in the descending order.
+        Currently this method only supports filtering the results by the
+        branch name.
+        There is no support for paging of results, but a limit on the
+        number of the results to return may be specified.
+        The returned results are ordered by the timestamp in descending
+        order.
 
         :param twisted.web.http.Request request: The request.
         """

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -198,7 +198,6 @@ class BenchmarkAPI_V1(object):
         d = self.backend.query(filter, limit)
 
         def got_results(results):
-            msg("got {} results (limit = {})".format(len(results), limit))
             result = {"version": self.version, "results": results}
             return dumps(result)
 

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -5,7 +5,6 @@ A HTTP REST API for storing benchmark results.
 
 import sys
 
-from collections import OrderedDict
 from json import dumps, loads
 from uuid import uuid4
 from urlparse import urljoin
@@ -52,7 +51,7 @@ class InMemoryBackend(object):
         def get_timestamp(result):
             return timestamp_parser.parse(result['timestamp'])
 
-        self._results = OrderedDict()
+        self._results = dict()
         self._sorted = SortedList(key=get_timestamp)
 
     def store(self, result):

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -137,7 +137,6 @@ class BenchmarkAPI_V1(object):
         request.setHeader(b'content-type', b'application/json')
         try:
             json = loads(request.content.read())
-            json['userdata']['branch']
             timestamp_parser.parse(json['timestamp'])
         except KeyError as e:
             raise BadRequest("'{}' is missing".format(e.message))

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -273,9 +273,9 @@ class BenchmarkAPITests(TestCase):
         req.addCallback(self.check_response_code, http.NOT_FOUND)
         return req
 
-    BRANCH1_RESULT1 = {u"branch": u"1", u"value": 100}
-    BRANCH1_RESULT2 = {u"branch": u"1", u"value": 120}
-    BRANCH2_RESULT1 = {u"branch": u"2", u"value": 110}
+    BRANCH1_RESULT1 = {u"userdata": {u"branch": u"1"}, u"value": 100}
+    BRANCH1_RESULT2 = {u"userdata": {u"branch": u"1"}, u"value": 120}
+    BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110}
 
     def setup_results(self):
         """
@@ -307,11 +307,14 @@ class BenchmarkAPITests(TestCase):
         """
         query = {}
         if filter:
-            query["filter"] = filter
+            query = filter.copy()
         if limit:
             query["limit"] = limit
-        json = StringProducer(dumps(query))
-        req = self.agent.request("POST", "/query", bodyProducer=json)
+        if query:
+            query_string = "?" + urlencode(query)
+        else:
+            query_string = ""
+        req = self.agent.request("GET", "/benchmark-results" + query_string)
         req.addCallback(self.check_response_code, 200)
         req.addCallback(client.readBody)
         return req

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -277,11 +277,11 @@ class BenchmarkAPITests(TestCase):
         return req
 
     BRANCH1_RESULT1 = {u"userdata": {u"branch": u"1"}, u"value": 100,
-                       u"timestamp": datetime.now().isoformat()}
+                       u"timestamp": datetime(2016, 1, 1, 0, 0, 5).isoformat()}
     BRANCH1_RESULT2 = {u"userdata": {u"branch": u"1"}, u"value": 120,
-                       u"timestamp": datetime.now().isoformat()}
+                       u"timestamp": datetime(2016, 1, 1, 0, 0, 6).isoformat()}
     BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110,
-                       u"timestamp": datetime.now().isoformat()}
+                       u"timestamp": datetime(2016, 1, 1, 0, 0, 7).isoformat()}
 
     def setup_results(self):
         """

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -58,7 +58,7 @@ class BenchmarkAPITests(TestCase):
     # because we test HTTP requests via an actual TCP/IP connection.
     run_tests_with = AsynchronousDeferredRunTest.make_factory(timeout=1)
 
-    RESULT = {'branch': 'branch1', 'run': 1, 'result': 1}
+    RESULT = {u"userdata": {u"branch": "master"}, u"run": 1, u"result": 1}
 
     def setUp(self):
         super(BenchmarkAPITests, self).setUp()

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -61,7 +61,7 @@ class BenchmarkAPITests(TestCase):
     run_tests_with = AsynchronousDeferredRunTest.make_factory(timeout=1)
 
     RESULT = {u"userdata": {u"branch": "master"}, u"run": 1, u"result": 1,
-              u"timestamp": datetime.now().isoformat(), }
+              u"timestamp": datetime(2016, 1, 1, 0, 0, 5).isoformat(), }
 
     def setUp(self):
         super(BenchmarkAPITests, self).setUp()

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -361,8 +361,9 @@ class BenchmarkAPITests(TestCase):
         result.
 
         :param response: The response to check.
-        :param expected_result:
-        :type expected: list of dict
+        :param expected_results: The expected results that should be in
+            the response.
+        :type expected_results: list of dict
         :param expected_code: The expected response code.
         """
         self.check_response_code(response, expected_code)

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -1,4 +1,5 @@
 from json import dumps, loads
+from urllib import urlencode
 from urlparse import urljoin
 
 from twisted.application.internet import StreamServerEndpointService
@@ -333,7 +334,7 @@ class BenchmarkAPITests(TestCase):
         self.assertEqual(data['version'], 1)
         self.assertIn('results', data)
         results = data['results']
-        self.assertItemsEqual(results, expected)
+        self.assertItemsEqual(expected, results)
 
     def test_query_no_filter_no_limit(self):
         """

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -424,7 +424,7 @@ class BenchmarkAPITests(TestCase):
         )
         return d
 
-    def test_error_with_unsupported_query_arg(self):
+    def test_unsupported_query_arg(self):
         """
         ``query`` raises ``BadRequest`` when an unsupported query
         argument is specified.
@@ -435,7 +435,7 @@ class BenchmarkAPITests(TestCase):
         d.addCallback(lambda _: flush_logged_errors(BadRequest))
         return d
 
-    def test_error_with_multiple_query_args_of_same_type(self):
+    def test_multiple_query_args_of_same_type(self):
         """
         ``query`` raises ``BadRequest`` when multiple values for a key
         are specified.
@@ -446,7 +446,7 @@ class BenchmarkAPITests(TestCase):
         d.addCallback(lambda _: flush_logged_errors(BadRequest))
         return d
 
-    def test_error_with_non_integer_limit_query_arg(self):
+    def test_non_integer_limit_query_arg(self):
         """
         ``query`` raises ``BadRequest`` when a non-integer value is
         is specified for the `limit` key.

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from json import dumps, loads
+from random import shuffle
 from urllib import urlencode
 from urlparse import urljoin
 
@@ -290,6 +291,7 @@ class BenchmarkAPITests(TestCase):
         results = [
             self.BRANCH1_RESULT1, self.BRANCH1_RESULT2, self.BRANCH2_RESULT1
         ]
+        shuffle(results)
 
         def chained_submit(_, result):
             """

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from json import dumps, loads
-from random import shuffle
 from urllib import urlencode
 from urlparse import urljoin
 
@@ -280,18 +279,22 @@ class BenchmarkAPITests(TestCase):
     BRANCH1_RESULT1 = {u"userdata": {u"branch": u"1"}, u"value": 100,
                        u"timestamp": datetime(2016, 1, 1, 0, 0, 5).isoformat()}
     BRANCH1_RESULT2 = {u"userdata": {u"branch": u"1"}, u"value": 120,
-                       u"timestamp": datetime(2016, 1, 1, 0, 0, 6).isoformat()}
-    BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110,
                        u"timestamp": datetime(2016, 1, 1, 0, 0, 7).isoformat()}
+    BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110,
+                       u"timestamp": datetime(2016, 1, 1, 0, 0, 6).isoformat()}
+    BRANCH2_RESULT2 = {u"userdata": {u"branch": u"2"}, u"value": 110,
+                       u"timestamp": datetime(2016, 1, 1, 0, 0, 8).isoformat()}
 
     def setup_results(self):
         """
         Submit some results for testing various queries against them.
         """
+
+        # Shuffle the results before submitting them.
         results = [
-            self.BRANCH1_RESULT1, self.BRANCH1_RESULT2, self.BRANCH2_RESULT1
+            self.BRANCH2_RESULT1, self.BRANCH1_RESULT1, self.BRANCH2_RESULT2,
+            self.BRANCH1_RESULT2
         ]
-        shuffle(results)
 
         def chained_submit(_, result):
             """
@@ -341,7 +344,7 @@ class BenchmarkAPITests(TestCase):
         self.assertEqual(data['version'], 1)
         self.assertIn('results', data)
         results = data['results']
-        self.assertItemsEqual(expected, results)
+        self.assertEqual(expected, results)
 
     def test_query_no_filter_no_limit(self):
         """
@@ -352,8 +355,8 @@ class BenchmarkAPITests(TestCase):
         d.addCallback(
             self.check_query_result,
             expected=[
-                self.BRANCH1_RESULT1, self.BRANCH1_RESULT2,
-                self.BRANCH2_RESULT1
+                self.BRANCH2_RESULT2, self.BRANCH1_RESULT2,
+                self.BRANCH2_RESULT1, self.BRANCH1_RESULT1
             ],
         )
         return d
@@ -367,14 +370,14 @@ class BenchmarkAPITests(TestCase):
         d.addCallback(
             self.check_query_result,
             expected=[
-                self.BRANCH1_RESULT1, self.BRANCH1_RESULT2,
+                self.BRANCH1_RESULT2, self.BRANCH1_RESULT1,
             ],
         )
         d.addCallback(self.run_query, filter={u"branch": u"2"})
         d.addCallback(
             self.check_query_result,
             expected=[
-                self.BRANCH2_RESULT1
+                self.BRANCH2_RESULT2, self.BRANCH2_RESULT1
             ],
         )
         return d
@@ -390,8 +393,8 @@ class BenchmarkAPITests(TestCase):
         d.addCallback(
             self.check_query_result,
             expected=[
-                self.BRANCH1_RESULT2,
-                self.BRANCH2_RESULT1
+                self.BRANCH2_RESULT2,
+                self.BRANCH1_RESULT2
             ],
         )
         return d

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -310,8 +310,8 @@ class BenchmarkAPITests(TestCase):
         Invoke the query interface of the HTTP API.
 
         :param dict filter: The data that the results must include.
-        :param int limit: The limit on how many results to turn.
-        :return" Deferred that fires with content of a response.
+        :param int limit: The limit on how many results to return.
+        :return: Deferred that fires with content of a response.
         """
         query = {}
         if filter:
@@ -329,8 +329,8 @@ class BenchmarkAPITests(TestCase):
 
     def check_query_result(self, body, expected):
         """
-        Check that the given response content is valid JSON
-        that contains the expect result.
+        Check that the given response content is valid JSON that
+        contains the expected resut.
 
         :param str body: The content to check.
         :param expected: The expected results.
@@ -360,7 +360,7 @@ class BenchmarkAPITests(TestCase):
 
     def test_query_with_filter(self):
         """
-        All matching results are returned if filter is given.
+        All matching results are returned if a filter is given.
         """
         d = self.setup_results()
         d.addCallback(self.run_query, filter={u"branch": u"1"})
@@ -382,8 +382,8 @@ class BenchmarkAPITests(TestCase):
     def test_query_with_limit(self):
         """
         The latest ``limit`` results are returned if no filter is set
-        but the limit is specified and the total number of the results
-        is greater than the limit.
+        and the specified limit is less than the total number of
+        results.
         """
         d = self.setup_results()
         d.addCallback(self.run_query, limit=2)
@@ -398,10 +398,9 @@ class BenchmarkAPITests(TestCase):
 
     def test_query_with_filter_and_limit(self):
         """
-        The expected number of matching results is returned
-        if the total number of such results is greater than
-        the limit.  The returned results are the latest among
-        the matching results.
+        The latest ``limit`` results which match the specified filter
+        are returned if the limit is less than the total number of
+        results.
         """
         d = self.setup_results()
         d.addCallback(self.run_query, filter={u"branch": u"1"}, limit=1)

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from json import dumps, loads
 from urllib import urlencode
 from urlparse import urljoin
@@ -58,7 +59,8 @@ class BenchmarkAPITests(TestCase):
     # because we test HTTP requests via an actual TCP/IP connection.
     run_tests_with = AsynchronousDeferredRunTest.make_factory(timeout=1)
 
-    RESULT = {u"userdata": {u"branch": "master"}, u"run": 1, u"result": 1}
+    RESULT = {u"userdata": {u"branch": "master"}, u"run": 1, u"result": 1,
+              u"timestamp": datetime.now().isoformat(), }
 
     def setUp(self):
         super(BenchmarkAPITests, self).setUp()
@@ -274,9 +276,12 @@ class BenchmarkAPITests(TestCase):
         req.addCallback(self.check_response_code, http.NOT_FOUND)
         return req
 
-    BRANCH1_RESULT1 = {u"userdata": {u"branch": u"1"}, u"value": 100}
-    BRANCH1_RESULT2 = {u"userdata": {u"branch": u"1"}, u"value": 120}
-    BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110}
+    BRANCH1_RESULT1 = {u"userdata": {u"branch": u"1"}, u"value": 100,
+                       u"timestamp": datetime.now().isoformat()}
+    BRANCH1_RESULT2 = {u"userdata": {u"branch": u"1"}, u"value": 120,
+                       u"timestamp": datetime.now().isoformat()}
+    BRANCH2_RESULT1 = {u"userdata": {u"branch": u"2"}, u"value": 110,
+                       u"timestamp": datetime.now().isoformat()}
 
     def setup_results(self):
         """

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,1 @@
 testtools==1.8.1
-python-dateutil==2.4.2
-sortedcontainers==1.4.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
 testtools==1.8.1
+python-dateutil==2.4.2
+sortedcontainers==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ klein==0.2.3
 Twisted==15.5.0
 Werkzeug==0.10.4
 zope.interface==4.1.2
+python-dateutil==2.4.2
+sortedcontainers==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 klein==0.2.3
+python-dateutil==2.4.2
+sortedcontainers==1.4.4
 Twisted==15.5.0
 Werkzeug==0.10.4
 zope.interface==4.1.2
-python-dateutil==2.4.2
-sortedcontainers==1.4.4


### PR DESCRIPTION
This is a minimal implementation of the query interface.
The results paging is not supported, the sort order is fixed and only querying by a branch name is supported. The interface can be extended later on as necessary.
See FLOC-3774 for a proposed advanced query interface.