### PR TITLE
[FLOC-3770] Add MongoDB backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ sudo: false
 install:
   - pip install -e .[dev]
 
+services:
+  - mongodb
+
 script:
-  - trial benchmark.test
+  - trial benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ sudo: false
 install:
   - pip install -e .[dev]
 
-services:
-  - mongodb
+addons:
+  apt:
+    sources:
+      - mongodb-upstart
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server
+      - mongodb-org-shell
 
+before_script:
+  - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"
 script:
   - trial benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install -e .[dev]
 
 script:
-  - trial benchmark
+  - trial benchmark.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ addons:
 
 before_script:
   - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"
+
 script:
   - trial benchmark

--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -11,6 +11,13 @@ class IBackend(Interface):
     A backend for storing and querying the results.
     """
 
+    def disconnect():
+        """
+        Perform necessary disconnect and cleanup actions.
+
+        :return: A Deferred that fires when the cleanup is done.
+        """
+
     def store(result):
         """
         Store a single benchmarking result.

--- a/benchmark/functional/test_httpapi.py
+++ b/benchmark/functional/test_httpapi.py
@@ -1,5 +1,7 @@
 from testtools import TestCase
 
+from twisted.web.http import CREATED
+
 from ..httpapi import TxMongoBackend
 from ..test.test_httpapi import BenchmarkAPITestsMixin
 
@@ -17,8 +19,9 @@ class TxMongoBenchmarkAPITests(BenchmarkAPITestsMixin, TestCase):
         req = super(TxMongoBenchmarkAPITests, self).submit(result)
 
         def add_cleanup(response):
-            location = response.headers.getRawHeaders(b'Location')[0]
-            self.addCleanup(lambda: self.agent.request("DELETE", location))
+            if response.code == CREATED:
+                location = response.headers.getRawHeaders(b'Location')[0]
+                self.addCleanup(lambda: self.agent.request("DELETE", location))
             return response
 
         req.addCallback(add_cleanup)

--- a/benchmark/functional/test_httpapi.py
+++ b/benchmark/functional/test_httpapi.py
@@ -1,0 +1,15 @@
+from testtools import TestCase
+
+from ..httpapi import TxMongoBackend
+from ..test.test_httpapi import BenchmarkAPITestsMixin
+
+
+class TxMongoBenchmarkAPITests(BenchmarkAPITestsMixin, TestCase):
+    def setUp(self):
+        self.backend = TxMongoBackend()
+        self.addCleanup(self.backend.disconnect)
+        super(TxMongoBenchmarkAPITests, self).setUp()
+
+    def tearDown(self):
+        super(TxMongoBenchmarkAPITests, self).tearDown()
+        return self.backend.collection.delete_many({})

--- a/benchmark/functional/test_httpapi.py
+++ b/benchmark/functional/test_httpapi.py
@@ -1,7 +1,5 @@
 from testtools import TestCase
 
-from twisted.web.http import CREATED
-
 from ..httpapi import TxMongoBackend
 from ..test.test_httpapi import BenchmarkAPITestsMixin
 
@@ -11,18 +9,3 @@ class TxMongoBenchmarkAPITests(BenchmarkAPITestsMixin, TestCase):
         self.backend = TxMongoBackend()
         self.addCleanup(self.backend.disconnect)
         super(TxMongoBenchmarkAPITests, self).setUp()
-
-    def submit(self, result):
-        """
-        Submit a result.
-        """
-        req = super(TxMongoBenchmarkAPITests, self).submit(result)
-
-        def add_cleanup(response):
-            if response.code == CREATED:
-                location = response.headers.getRawHeaders(b'Location')[0]
-                self.addCleanup(lambda: self.agent.request("DELETE", location))
-            return response
-
-        req.addCallback(add_cleanup)
-        return req

--- a/benchmark/functional/test_httpapi.py
+++ b/benchmark/functional/test_httpapi.py
@@ -10,6 +10,16 @@ class TxMongoBenchmarkAPITests(BenchmarkAPITestsMixin, TestCase):
         self.addCleanup(self.backend.disconnect)
         super(TxMongoBenchmarkAPITests, self).setUp()
 
-    def tearDown(self):
-        super(TxMongoBenchmarkAPITests, self).tearDown()
-        return self.backend.collection.delete_many({})
+    def submit(self, result):
+        """
+        Submit a result.
+        """
+        req = super(TxMongoBenchmarkAPITests, self).submit(result)
+
+        def add_cleanup(response):
+            location = response.headers.getRawHeaders(b'Location')[0]
+            self.addCleanup(lambda: self.agent.request("DELETE", location))
+            return response
+
+        req.addCallback(add_cleanup)
+        return req

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -162,7 +162,7 @@ class TxMongoBackend(object):
         # which can not be serialized to JSON. Either a custom
         # JSONEncoder or bson.json_util.dumps would be needed.
         d = self.collection.find_one(
-            filter={'_id': object_id},
+            {'_id': object_id},
             fields={'_id': False, 'sort$timestamp': False}
         )
         d.addCallback(post_process)

--- a/benchmark/httpapi.py
+++ b/benchmark/httpapi.py
@@ -414,8 +414,9 @@ def start_services(reactor, endpoint, backend):
     backend_service = BackendService(backend)
     backend_service.setServiceParent(top_service)
 
-    # XXX Make startService() raise an exception on an error
-    # instead of just logging and dropping it.
+    # XXX Setting _raiseSynchronously makes startService raise an exception
+    # on error rather than just logging and dropping it.
+    # This should be a public API, Twisted bug #8170.
     api_service._raiseSynchronously = True
     top_service.startService()
     reactor.addSystemEventTrigger(

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -331,7 +331,7 @@ class BenchmarkAPITests(TestCase):
         self.assertEqual(data['version'], 1)
         self.assertIn('results', data)
         results = data['results']
-        self.assertItemsEqual(results, expected)
+        self.assertItemsEqual(expected, results)
 
     def test_query_no_filter_no_limit(self):
         """

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -13,7 +13,7 @@ from testtools.deferredruntest import AsynchronousDeferredRunTest
 
 from zope.interface import implementer
 
-from benchmark.httpapi import BenchmarkAPI_V1, InMemoryBackend
+from ..httpapi import BenchmarkAPI_V1, InMemoryBackend
 
 
 @implementer(IBodyProducer)

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -49,7 +49,7 @@ class TestEndpoint(TCP4ServerEndpoint):
         return d
 
 
-class BenchmarkAPITests(TestCase):
+class BenchmarkAPITestsMixin(object):
     """
     Tests for BenchmarkAPI.
     """
@@ -60,10 +60,8 @@ class BenchmarkAPITests(TestCase):
     RESULT = {'branch': 'branch1', 'run': 1, 'result': 1}
 
     def setUp(self):
-        super(BenchmarkAPITests, self).setUp()
+        super(BenchmarkAPITestsMixin, self).setUp()
 
-        self.backend = InMemoryBackend()
-        self.addCleanup(self.backend.disconnect)
         api = BenchmarkAPI_V1(self.backend)
         site = server.Site(api.app.resource())
 
@@ -402,3 +400,9 @@ class BenchmarkAPITests(TestCase):
             ],
         )
         return d
+
+
+class InMemoryBenchmarkAPITests(BenchmarkAPITestsMixin, TestCase):
+    def setUp(self):
+        self.backend = InMemoryBackend()
+        super(InMemoryBenchmarkAPITests, self).setUp()

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -103,6 +103,15 @@ class BenchmarkAPITestsMixin(object):
         body = StringProducer(json)
         req = self.agent.request("POST", "/benchmark-results",
                                  bodyProducer=body)
+
+        def add_cleanup(response):
+            if response.code == http.CREATED:
+                location = response.headers.getRawHeaders(b'Location')[0]
+                self.addCleanup(lambda: self.agent.request("DELETE", location))
+            return response
+
+        req.addCallback(add_cleanup)
+
         return req
 
     def check_response_code(self, response, expected_code):

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -63,6 +63,7 @@ class BenchmarkAPITests(TestCase):
         super(BenchmarkAPITests, self).setUp()
 
         self.backend = InMemoryBackend()
+        self.addCleanup(self.backend.disconnect)
         api = BenchmarkAPI_V1(self.backend)
         site = server.Site(api.app.resource())
 

--- a/benchmark/test/test_httpapi.py
+++ b/benchmark/test/test_httpapi.py
@@ -270,6 +270,10 @@ class BenchmarkAPITestsMixin(object):
         Deleted result can not be retrieved.
         """
         req = self.submit(self.RESULT)
+        # Submit another result, so that we can catch a situation
+        # where we get a wrong result instead of the requested,
+        # already removed one.
+        req = req.addCallback(lambda _: self.submit(self.RESULT))
 
         def delete_and_get(response):
             location = response.headers.getRawHeaders(b'Location')[0]
@@ -288,6 +292,9 @@ class BenchmarkAPITestsMixin(object):
         Deleted result can not be deleted again.
         """
         req = self.submit(self.RESULT)
+        # Submit another result to make sure that the second delete
+        # does not succeed on a wrong result.
+        req = req.addCallback(lambda _: self.submit(self.RESULT))
 
         def delete_twice(response):
             location = response.headers.getRawHeaders(b'Location')[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ klein==0.2.3
 Twisted==15.5.0
 Werkzeug==0.10.4
 zope.interface==4.1.2
+txmongo==15.3.1


### PR DESCRIPTION
This change adds support for using a MongoDB backend. It uses [TxMongo](https://github.com/twisted/txmongo) as the driver.

The same set of tests that are available for the InMemoryBackend are used with this backend. If the MongoDB backend is selected, then the default connection details are `127.0.0.1:27017`. This can be changed using the newly added command line switches.

The documentation on how to use MongoDB is pending however it would be helpful to have the code changes reviewed so far.
